### PR TITLE
Update .JuliaFormatter.toml

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -5,3 +5,4 @@ annotate_untyped_fields_with_any = true
 import_to_using = false
 indent = 2
 short_to_long_function_def = false
+always_for_in = true


### PR DESCRIPTION
Adding `always_for_in = true` here should not effect things for most people, as `style = "blue"` should already include this, but for some reason my editor (which admittedly uses an outdated JuliaFormatter.jl) does not respect this without including this line explicitly.